### PR TITLE
chore(release): @piper-plus/g2p 0.4.2 — 辞書 404 と MIT 許諾文欠落を解消

### DIFF
--- a/src/wasm/g2p/CHANGELOG.md
+++ b/src/wasm/g2p/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.2] - 2026-08-27
+## [0.4.2] - 2026-08-28
 
 ### Fixed
 

--- a/src/wasm/g2p/CHANGELOG.md
+++ b/src/wasm/g2p/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-08-27
+
+### Fixed
+
+- **Default Japanese dictionary download returned HTTP 404 (Issue #634)**: `DICT_TAR_GZ_URL` in `src/dict-loader.js` pointed at `ayutaz/piper-plus` release tag `dict-v1.0.0`, which does not exist. Any consumer that did not pass an explicit `dictUrl` therefore hit a 404 and Japanese G2P failed every time. The URL now matches the canonical source the Rust / C# / C++ runtimes already use (`r9y9/open_jtalk` v1.11.1); `DICT_SHA256` was already the checksum for that archive, so only the one line was wrong.
+- **Package declared MIT but shipped no license text (Issue #640)**: `package.json` set `"license": "MIT"` while the published tarball contained no `LICENSE` file of any kind, which the MIT terms do not permit — the copyright and permission notice must accompany every copy. `LICENSE.md` is now included in `files`. The same change drops `dist/openjtalk.js` and `dist/openjtalk.wasm` from `files`: the Emscripten OpenJTalk build was retired in #301 and nothing has produced those artifacts since, so npm was silently discarding both entries and the tarball never contained a `dist/` directory at all.
+
 ## [0.4.1] - 2026-06-07
 
 ### Added

--- a/src/wasm/g2p/package.json
+++ b/src/wasm/g2p/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piper-plus/g2p",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Multilingual G2P (Grapheme-to-Phoneme) for TTS — eSpeak-ng free, MIT licensed",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary

`@piper-plus/g2p` 0.4.2 のリリース準備。公開中の 0.4.1 は 2 つの実害を抱えている — 辞書ダウンロードの既定 URL が存在しないタグを指しており `dictUrl` を明示しない限り日本語 G2P が必ず 404 で失敗すること (#634)、そして `license: MIT` を宣言しながら tarball に許諾文を 1 バイトも含んでいないこと (#640)。

修正自体は #635 / #640 で既に `dev` にマージ済みなので、本 PR は**版 bump と CHANGELOG のみ**。機能変更は一切含まない。

`piper-plus` (openjtalk-web) は意図的に**含めていない** — 理由は「設計判断」に記載。

## Affected Components

- [ ] Python (piper_train / piper_plus)
- [ ] Rust
- [ ] C#
- [ ] C++
- [ ] Go
- [x] WASM / npm
- [ ] Docker
- [ ] CI/CD
- [x] Documentation

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Dependencies
- [x] Release preparation

## Risk Level

- [x] patch (bugfix / 内部変更)
- [ ] minor (新機能 / 非破壊)
- [ ] major (破壊的変更)

## Contract Impact

- [x] None — `docs/spec/*.toml` への影響なし

> `docs/spec/release-versions.toml` の `[npm.g2p] expected_prefix = "0.4."` が 0.4.2 を包含するため toml 変更は不要。`check_version_manifest_sync.py --strict` が 10 manifest 一致で通過することを確認済み。

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|---|---|---|
| `package.json` version bump | 0.4.1 → 0.4.2 | `npm-publish` 系の tag ゲートが版不一致で fail し、そもそもリリースできない |
| `CHANGELOG.md` に `[0.4.2]` 追加 | Fixed 2 件を英語プロースで記載 | CHANGELOG は `files` に含まれ tarball に同梱されるため、利用者が registry 上で何が直ったか読めない |

出荷される修正 (実装は既に `dev` にある):

| Issue | 内容 |
|---|---|
| #634 | `src/dict-loader.js` の `DICT_TAR_GZ_URL` が存在しない `ayutaz/piper-plus@dict-v1.0.0` を指していた → canonical な `r9y9/open_jtalk` v1.11.1 へ。`DICT_SHA256` は元から後者の値と一致していたため、誤っていたのは URL の 1 行のみ |
| #640 | `LICENSE.md` を `files` に追加。併せて生成手段が #301 で消滅した `dist/openjtalk.js` / `dist/openjtalk.wasm` の宣言を削除 (npm が無警告で捨てており tarball に `dist/` は 1 ファイルも無かった) |

## 設計判断

- **`piper-plus` (openjtalk-web) を同じ PR に入れない。** `piper-plus@0.7.0` は `@piper-plus/g2p: ^0.4.1` を宣言しており、`package-lock.json` も 0.4.1 を registry resolved で pin している。この状態で `npm-v0.7.0` を打つと、#634 の辞書修正が入る保証のない manifest が**恒久的に焼かれる**。floor を `^0.4.2` に上げるには 0.4.2 が registry に存在している必要がある (lockfile の `resolved` / `integrity` が解決できない) ため、1 つの PR では閉じられない。よって「g2p を先に公開 → floor 引き上げ → piper-plus を公開」の順に分ける。

- **`docs/spec/release-versions.toml` を触らない。** `expected_prefix = "0.4."` が 0.4.2 を包含する。帯をまたぐ場合のみ同一 commit で更新するのが前例 (`abf2877a`)。

- **link reference definition を追加しない。** ファイル末尾の既存 `[0.1.0]` / `[0.2.0]` / `[0.3.0]` は参照先タグが存在しない死に link であり、新規に追加すると不整合を広げる。`1cd87db2` (#554) の promote も同じ扱い。

- **CHANGELOG は英語で書く。** `files` に含まれ npm tarball に同梱されるため、registry 上で利用者に直接読まれる。既存 `[0.4.1]` の書式 (太字リード句 + コロン + 因果の説明) に揃えた。

- **#622 は記載しない。** `wasm-g2p-v0.4.1..HEAD -- src/wasm/g2p/` の変更を確認したところ、#622 は g2p npm パッケージの出荷物に影響しない。

## Test Plan

- [ ] `cd src/wasm/g2p && npm test` → 1330 tests / 1329 pass / 1 skip / 0 fail
- [ ] `cd src/wasm/g2p && npm pack --dry-run --json` → version `0.4.2` / total files 23 / `LICENSE.md` を含む / `dist/` が 0 ファイル
- [ ] `python3 scripts/check_changelog_format.py src/wasm/g2p/CHANGELOG.md` → passed (L29 の WARN は `[0.3.0]` セクション由来の既存分)
- [ ] `uv run --no-sync python scripts/check_version_manifest_sync.py --strict` → 10 manifest 一致
- [ ] `uvx codespell src/wasm/g2p/CHANGELOG.md src/wasm/g2p/package.json` → exit 0
- [ ] `npm view @piper-plus/g2p@0.4.2 version` → E404 (版番号が未使用であること)
- [ ] `git status --porcelain` → 変更は `src/wasm/g2p/{package.json,CHANGELOG.md}` の 2 ファイルのみ

## Checklist

- [x] Tests pass locally
- [x] No GPL/LGPL dependencies added
- [x] Documentation updated (CHANGELOG)

## Related Issues

なし (#634 / #640 の修正を registry へ届けるためのリリース準備)

---

### マージ後の手順 (このPRには含まれない)

1. `wasm-g2p-v0.4.2` タグを dev の HEAD に push → `g2p-wasm-ci.yml` の publish job (`if: startsWith(github.ref, 'refs/tags/wasm-g2p-v')`) が発火
2. `npm view @piper-plus/g2p versions` に 0.4.2 が現れるのを確認
3. 別 PR で `src/wasm/openjtalk-web/package.json` の floor を `^0.4.2` に上げ、`package-lock.json` を再生成
4. それをマージした SHA に `npm-v0.7.0` を打つ

本 PR のマージ自体では **何も publish されない** (両 publish job がタグ限定であることを確認済み)。
