### PR TITLE
chore(release): piper-plus 0.7.0 準備 — g2p floor 引き上げと CHANGELOG 整備

### DIFF
--- a/src/wasm/openjtalk-web/CHANGELOG.md
+++ b/src/wasm/openjtalk-web/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-28
+
 ### Added
 
 #### SSML 合成統合 (synthesize 側)
@@ -22,6 +24,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **仕様:** `docs/spec/ssml-contract.toml` (`applies_to` に `"wasm"` を追加、status table を ✓ に更新)。`tests/fixtures/ssml/contract.json` と byte-for-byte 互換。
 
 **テスト:** `test/js/test-piper-plus-ssml.js` (23 件): re-export 確認 / `synthesize()` 自動 dispatch / segment iteration / `length_scale` 適用 / silence 挿入 / fixture parity。
+#### Speaker Encoder synthesize 統合 (#478)
+
+参照音声から話者埋め込みを作り、そのまま合成に流せる高位 API をブラウザ側に追加。CLI の `--reference-audio` + `--speaker-encoder-model` に相当する経路が JS だけで完結する。
+
+**新規 API:**
+
+- `PiperPlus.synthesizeFromReferenceAudio({ text, referenceWav, encoder })` — 参照 WAV をエンコードし、得られた埋め込みを `synthesize()` に `speakerEmbedding` として渡す
+- `synthesize(text, { speakerEmbedding })` — `SynthesizeOptions` に `speakerEmbedding` を追加
+- 型: `SynthesizeFromReferenceAudioParams`
+
+#### CLI エントリポイント
+
+- `package.json` に `bin` を追加 (`piper-plus` → `bin/piper-cli.js`)。インストールすると `node_modules/.bin/piper-plus` が生え、グローバルインストールでは `piper-plus` コマンドが作られる
+- **注意:** PyPI 版 `piper-plus` の console script と同名。両方をグローバルに入れている場合は PATH 上で衝突しうる
+
+#### その他の公開 API 追加
+
+- `trimEosRegion` — EOS 領域トリムを Rust / Go / C# / C++ とそろえた (#507)
+- ORT ウォームアップ定数 8 種 (`WARMUP_BOS_TOKEN` / `WARMUP_EOS_TOKEN` / `WARMUP_DEFAULT_RUNS` / `WARMUP_DUMMY_PHONEME` / `WARMUP_LENGTH_SCALE` / `WARMUP_NOISE_SCALE` / `WARMUP_NOISE_W` / `WARMUP_PHONEME_LENGTH`) — `docs/spec/ort-session-contract.toml` の値をコードから参照可能に
+- `RustWasmAdapter.create()` の `options.jaDict` — `ja-external` / `multilingual-external` variant 向けに外部 JA 辞書を opt-in で投入する (#640)。取得 → SHA-256 検証 → 投入の順で適用し、既定 URL は持たない
+- `RustWasmAdapter#japaneseDictionaryStatus` — 上記の結果を `"not-requested"` / `"unsupported"` / `"loaded"` / `"failed"` で公開 (#640)
+
+### Deprecated
+
+- `PiperPlus.synthesizeWithVoiceCloning(text, speakerEmbedding, options)` — `synthesize(text, { speakerEmbedding })` に置き換え。後方互換のため残しており、削除は将来のメジャーリリースで行う (#478)
+
+### Removed
+
+- `exports` から `./wasm/ja` と `./wasm/ja-lite` を削除 (#640)。この 2 つは #301 で宣言されて以来どの公開版でも実体 0 ファイルで、0.6.0 の tarball でも `require.resolve` が `MODULE_NOT_FOUND` になる状態だった。依存できた利用者は存在しないため実質的な破壊的変更ではない
+
+### Fixed
+
+- `files` に `bin/**/*.js` を追加。これがないと `bin` で宣言した CLI が tarball に入らない (#640)
+
+## [0.6.0] - 2026-05-04
+
+### Added
 
 #### Phoneme Timing 機能 (新規モジュール)
 
@@ -73,10 +112,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - "Phoneme Timing for Lip-Sync & Subtitles" セクション追加
 - Viseme マッピング例
 - Output format リファレンス
-
-### Tests
-
-- 全テスト: 376 passed, 1 skipped, 0 failed (リグレッション 0 件)
 
 ## [0.4.0] - 2026-04-12
 

--- a/src/wasm/openjtalk-web/package-lock.json
+++ b/src/wasm/openjtalk-web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@piper-plus/g2p": "^0.4.1"
+        "@piper-plus/g2p": "^0.4.2"
       },
       "bin": {
         "piper-plus": "bin/piper-cli.js"
@@ -289,9 +289,9 @@
       }
     },
     "node_modules/@piper-plus/g2p": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@piper-plus/g2p/-/g2p-0.4.1.tgz",
-      "integrity": "sha512-cVQ8u+DcQQas2KLGL7MV48YsKjvBOQhHK/LveSSkUBbP8ajxi3h1cSuq+AwW9AvInAm/Dqtg/3r4gPL64XY1ww==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@piper-plus/g2p/-/g2p-0.4.2.tgz",
+      "integrity": "sha512-iEuynnOXOmZw88dUfyLrolRO0U3gIviIAqJR0N8SbFvoKq/dFtmZkBFtgpThk8Lk+r+rcfW0se+PkJqMPJgE4g==",
       "license": "MIT",
       "engines": {
         "node": ">=24.0.0"

--- a/src/wasm/openjtalk-web/package.json
+++ b/src/wasm/openjtalk-web/package.json
@@ -69,7 +69,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@piper-plus/g2p": "^0.4.1"
+    "@piper-plus/g2p": "^0.4.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.10.0",


### PR DESCRIPTION
## Summary

`piper-plus` (npm) 0.7.0 のリリース準備。version は `abf2877a` (#560) で既に 0.7.0 に bump 済みで未公開のため、本 PR が行うのは **g2p 依存の floor 引き上げと CHANGELOG の整備**。機能変更は一切含まない。

前段の #641 で `@piper-plus/g2p` 0.4.2 を公開済み。これで floor を `^0.4.2` に上げられるようになった。

## Affected Components

- [ ] Python (piper_train / piper_plus)
- [ ] Rust
- [ ] C#
- [ ] C++
- [ ] Go
- [x] WASM / npm
- [ ] Docker
- [ ] CI/CD
- [x] Documentation

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [x] Dependencies
- [x] Release preparation

## Risk Level

- [ ] patch (bugfix / 内部変更)
- [x] minor (新機能 / 非破壊)
- [ ] major (破壊的変更)

## Contract Impact

- [x] None — `docs/spec/*.toml` への影響なし

> `docs/spec/release-versions.toml` の `[npm.synthesis] expected_prefix = "0.7."` と一致するため toml 変更は不要。

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|---|---|---|
| `@piper-plus/g2p` の floor 引き上げ | `^0.4.1` → `^0.4.2` + lockfile を registry 解決で再生成 | `^0.4.1` のまま 0.7.0 が焼かれ、辞書 DL の 404 修正 (#634) が入る保証のない manifest が恒久的に残る |
| CHANGELOG の `[Unreleased]` 仕分け | Phoneme Timing を遡及 `[0.6.0]` へ、新規分を `[0.7.0]` へ | 2 世代前に出荷済みの機能を新機能として告知することになる |

## 設計判断

- **`[Unreleased]` を丸ごと 0.7.0 に昇格しない。** 公開済み 0.6.0 の tarball を展開したところ `src/timing.js` が既に含まれており、Phoneme Timing は出荷済みだった。しかも `[0.6.0]` セクション自体が欠けていた (次が `[0.4.0]`) ため、遡及セクションを新設して移した。

- **0.7.0 の記載内容はすべて 0.6.0 の実物と照合済み。** `synthesizeSsml` / `synthesizeFromReferenceAudio` / `trimEosRegion` / `WARMUP_*` / `synthesize()` の `speakerEmbedding` が、いずれも公開済み 0.6.0 の `types/index.d.ts` に存在しないことを確認したうえで記載している。

- **`synthesizeWithVoiceCloning` は `### Deprecated` に置く。** 0.6.0 と HEAD の両方に存在し、HEAD 側で `@deprecated` が付いただけ。削除ではないので Removed ではない。

- **未記載だった `bin` エントリを追記。** 0.6.0 の manifest は `bin` を持たず、0.7.0 で `piper-plus` → `bin/piper-cli.js` が追加される。グローバルインストールで実行ファイルが生え、PyPI 版 `piper-plus` の console script と同名で衝突しうるため、利用者から見える変更として明記した。

- **`exports` 削除を破壊的扱いにしない。** `./wasm/ja` / `./wasm/ja-lite` は 0.6.0 の tarball で実体 0 ファイルで、実際に `require.resolve` すると `MODULE_NOT_FOUND` になる。依存できた利用者が存在しないため 0.x の minor で妥当。

## Test Plan

- [ ] `cd src/wasm/openjtalk-web && npm install && npm run test:npm-package:all` → 810 tests / 809 pass / 1 skip / 0 fail
- [ ] `node -p "require('@piper-plus/g2p/package.json').version"` → `0.4.2` (symlink ではなく registry 版が入ること)
- [ ] `python3 -c "import json;d=json.load(open('src/wasm/openjtalk-web/package-lock.json'));print([v['resolved'] for k,v in d['packages'].items() if 'g2p' in k])"` → `registry.npmjs.org/@piper-plus/g2p/-/g2p-0.4.2.tgz`
- [ ] `uv run --no-sync python scripts/check_lockfile_size.py` → 4 lockfile が ±20% 以内
- [ ] `python3 scripts/check_changelog_format.py src/wasm/openjtalk-web/CHANGELOG.md` → passed (L118 / L139 の WARN は `[0.4.0]` / `[0.3.x]` 由来の既存分)
- [ ] `uvx codespell src/wasm/openjtalk-web/CHANGELOG.md` → exit 0
- [ ] `npm view piper-plus@0.7.0 version` → E404 (版番号が未使用であること)
- [ ] `git diff dev -- src/wasm/openjtalk-web/package.json` → 差分は floor の 1 行のみ

## Checklist

- [x] Tests pass locally
- [x] No GPL/LGPL dependencies added
- [x] Documentation updated (CHANGELOG)

## Related Issues

なし (#641 に続くリリース準備の第 2 段)

---

### マージ後の手順 (このPRには含まれない)

`npm-v0.7.0` タグを dev の HEAD に push → `npm-publish.yml` が発火し `piper-plus` 0.7.0 が公開される。

本 PR のマージ自体では **何も publish されない** (publish job がタグ限定であることを確認済み)。
