### PR TITLE
fix(ci): npm への公開を OIDC trusted publishing に切り替える

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -94,6 +94,11 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
 
+      - name: Upgrade npm for OIDC trusted publishing (>= 11.5.1)
+        # setup-node が入れる npm は OIDC trusted publishing に対応した
+        # 11.5.1 より古いことがある。g2p-wasm-ci.yml と同じ手当て。
+        run: npm install -g npm@latest
+
       - name: Download WASM artifact
         uses: actions/download-artifact@v8.0.1
         with:
@@ -129,6 +134,10 @@ jobs:
         # Publishes the already-packed tarball with both SLSA-provenance
         # (GitHub artifact attestation, attached above) and npm-provenance
         # (sigstore via --provenance, attached by the registry).
+        #
+        # OIDC trusted publishing: NODE_AUTH_TOKEN は設定しない。npm は
+        # トークンが存在するとそちらを優先し、org の 2FA 強制下では OTP を
+        # 要求して EOTP で失敗する (npm-v0.7.0 の初回 publish が実際にこれで
+        # 落ちた)。permissions.id-token: write の OIDC token で npm 側の
+        # Trusted Publisher 設定に対して認証する。g2p-wasm-ci.yml と同じ構成。
         run: npm publish *.tgz --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

`npm-v0.7.0` の公開が `EOTP` (one-time password 要求) で失敗した。`NODE_AUTH_TOKEN` を渡していたため npm がトークン認証を優先し、org の 2FA 強制下で OTP を求められたため。npm 自身もログで「2FA を bypass するトークンは direct publishing で制限される」と警告している。

`@piper-plus/g2p` は `g2p-wasm-ci.yml` で既に OIDC trusted publishing へ移行済みで、同日の 0.4.2 公開は成功している。`openjtalk-web` 側だけが旧構成のまま取り残されていた。

**版番号は焼かれていない** (registry の `piper-plus` は 0.6.0 のまま) ので、本 PR をマージ後にタグを打ち直せば公開できる。

## Affected Components

- [ ] Python (piper_train / piper_plus)
- [ ] Rust
- [ ] C#
- [ ] C++
- [ ] Go
- [ ] WASM / npm
- [ ] Docker
- [x] CI/CD
- [ ] Documentation

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] CI/CD
- [ ] Dependencies

## Risk Level

- [x] patch (bugfix / 内部変更)
- [ ] minor (新機能 / 非破壊)
- [ ] major (破壊的変更)

## Contract Impact

- [x] None — `docs/spec/*.toml` への影響なし

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|---|---|---|
| npm upgrade step 追加 | `npm install -g npm@latest` を publish job に追加 | OIDC trusted publishing は npm >= 11.5.1 が必要。setup-node が入れる npm はそれより古いことがある |
| `NODE_AUTH_TOKEN` 削除 | publish step の `env` から除去 | トークンが存在すると npm はそちらを優先するため、OIDC を設定しても EOTP のまま直らない |

`attestations: write` と `actions/attest-build-provenance` は `openjtalk-web` 固有 (g2p 側には無い) なので、そのまま残している。

## 設計判断

- **トークンを granular automation token に差し替えるのではなく OIDC に寄せる。** `g2p-wasm-ci.yml` のコメントが移行理由を「org の 2FA 強制を回避し、token 失効/期限切れも根絶する」と明記しており、同じ方向に揃えるのが一貫している。

- **registry のメタデータで両者の差を確認済み。** `@piper-plus/g2p@0.4.2` の `_npmUser` は `GitHub Actions` + `trustedPublisher: {id: "github", oidcConfigId: ...}` だが、`piper-plus@0.6.0` は個人アカウント名 (`ayousanz`) になっている。過去の `npm-v0.6.0` の workflow も `NODE_AUTH_TOKEN` を使っており、OIDC での成功実績は無かった。

- **npm 側の Trusted Publisher 登録は本 PR の前提。** `piper-plus` パッケージに repo `ayutaz/piper-plus` / workflow `npm-publish.yml` / Environment 空 で登録済み。publish job は GitHub Environment を使っていない (`permissions.id-token: write` のみ) ため、Environment 欄を空にする必要がある。

## Test Plan

- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/npm-publish.yml'))"` → エラーなし
- [ ] `grep -c 'NODE_AUTH_TOKEN' .github/workflows/npm-publish.yml` → 1 (コメント内の説明文のみ。`env:` 設定は存在しないこと)
- [ ] `actionlint .github/workflows/npm-publish.yml` → SC2035 が 1 件 (変更前と同数の既存指摘)
- [ ] publish job に `id-token: write` / `attestations: write` / `npm install -g npm@latest` が揃っていること
- [ ] マージ後: `npm-v0.7.0` タグを打ち直し、publish job が成功すること
- [ ] 公開後: `npm view piper-plus` の `_npmUser` が `GitHub Actions` + `trustedPublisher` になっていること (トークン公開との判別)

## Checklist

- [x] Tests pass locally
- [x] No GPL/LGPL dependencies added
- [ ] Documentation updated (該当なし)

## Related Issues

なし (`npm-v0.7.0` 公開失敗の是正)
