### PR TITLE
fix(ci): npm pack --json の形式変更 (npm 12) にゲートを追従させる

### DIFF
--- a/scripts/check_npm_exports_shipped.py
+++ b/scripts/check_npm_exports_shipped.py
@@ -62,9 +62,27 @@ def packed_paths(pkg_dir: Path) -> set[str]:
         print("ERROR: `npm pack --dry-run --json` failed:")
         print(proc.stderr.strip() or proc.stdout.strip())
         raise SystemExit(1)
-    # npm prints the JSON array on stdout; notices go to stderr.
+
+    # npm prints the JSON on stdout; notices go to stderr. The top-level shape
+    # changed between majors and both are in play here: the publish workflow
+    # upgrades to npm@latest for OIDC trusted publishing, while a developer's
+    # local npm is whatever their Node ships.
+    #
+    #   npm 11.x -> [ { name, files: [...], ... } ]
+    #   npm 12.x -> { "<pkg-name>": { name, files: [...], ... } }
+    #
+    # Only the envelope differs; each entry keeps the same keys.
     payload = json.loads(proc.stdout)
-    return {entry["path"] for entry in payload[0]["files"]}
+    if isinstance(payload, dict):
+        entries = list(payload.values())
+    else:
+        entries = list(payload)
+
+    if not entries:
+        print("ERROR: `npm pack --dry-run --json` reported no package.")
+        raise SystemExit(1)
+
+    return {entry["path"] for entry in entries[0]["files"]}
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

`npm-v0.7.0` の公開が `KeyError: 0` で止まった。#640 で追加した tarball ゲート (`scripts/check_npm_exports_shipped.py`) が `npm pack --dry-run --json` のトップレベルを配列決め打ちで読んでいたが、npm 12 で辞書に変わっていたため。

```
npm 11.x -> [ { name, files: [...], ... } ]            配列
npm 12.x -> { "<pkg-name>": { name, files: [...] } }   辞書
```

エントリの中身は同一で、envelope だけが違う。両形式を受けるようにする。

## Affected Components

- [ ] Python (piper_train / piper_plus)
- [ ] Rust
- [ ] C#
- [ ] C++
- [ ] Go
- [ ] WASM / npm
- [ ] Docker
- [x] CI/CD
- [ ] Documentation

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] CI/CD
- [ ] Dependencies

## Risk Level

- [x] patch (bugfix / 内部変更)
- [ ] minor (新機能 / 非破壊)
- [ ] major (破壊的変更)

## Contract Impact

- [x] None — `docs/spec/*.toml` への影響なし

## 変更内容

| 機能名 | 動作 | これがないと起こること |
|---|---|---|
| `packed_paths()` の envelope 両対応 | 辞書なら `values()`、配列ならそのままエントリ列として扱う | publish job が `KeyError: 0` で落ち、リリースが出せない |
| 空エントリの明示エラー | パッケージが 0 件なら理由付きで exit 1 | 将来また形式が変わったとき、無言で空集合を返して「全 target 欠落」と誤報するのを防ぐ |

## 設計判断

- **なぜローカルで再現しなかったか。** 開発環境の npm は Node 24 同梱の 11.13.0 で配列を返す。一方 publish job は #643 で OIDC のために `npm install -g npm@latest` を入れたため npm 12.0.2 になり、そこだけ辞書になった。つまり **#643 の修正が #640 のゲートを壊した**という組み合わせ由来の破損で、どちらか単体では起きない。

- **npm を pin せず両対応にする。** publish job は OIDC のため npm >= 11.5.1 を要求しており、`npm@latest` を使う限り将来また上がる。envelope 差を吸収するほうが、npm の版を固定して OIDC 要件と綱引きするより堅い。

- **両方の npm で実測確認した。** npm@latest (12.0.2) を隔離ディレクトリに入れ、`PATH` を差し替えて同じスクリプトを走らせている。

## Test Plan

- [ ] `mkdir -p src/wasm/openjtalk-web/dist/rust-wasm && echo 'export default 1;' > src/wasm/openjtalk-web/dist/rust-wasm/piper_plus_wasm.js && printf 'x' > src/wasm/openjtalk-web/dist/rust-wasm/piper_plus_wasm_bg.wasm`
- [ ] npm 11 系で `python3 scripts/check_npm_exports_shipped.py` → `OK all 8 exports target(s) present in the tarball` / exit 0
- [ ] `npm install npm@latest --prefix /tmp/npm12` して `PATH=/tmp/npm12/node_modules/.bin:$PATH python3 scripts/check_npm_exports_shipped.py` → 同じく exit 0
- [ ] 変異: `printf '*\n' > src/wasm/openjtalk-web/dist/rust-wasm/.gitignore` を置くと、npm 11 / npm 12 の**両方**で exit 1 になること
- [ ] 後片付け: `rm -rf src/wasm/openjtalk-web/dist/rust-wasm` して `git status --porcelain` が本 PR の 1 ファイルのみ
- [ ] マージ後: `npm-v0.7.0` タグを打ち直し、publish job が完走すること

## Checklist

- [x] Tests pass locally
- [x] No GPL/LGPL dependencies added
- [ ] Documentation updated (該当なし)

## Related Issues

なし (#640 のゲートと #643 の npm upgrade の組み合わせで生じた破損の是正)
